### PR TITLE
automatically build the binary on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: ubuntu:22.04
+    steps:
+      - name: Install tools
+        run: |
+          apt-get update
+          apt-get install -y libssl-dev pkg-config gcc wget git
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65.0
+          default: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "jito-shredstream-proxy-linux-x86_64"
+          path: target/release/jito-shredstream-proxy


### PR DESCRIPTION
This PR adds a GitHub workflow which automatically builds the binary on push.

I can also make it automatically create a release when pushing to the `release` branch. However, I need someone from the team to tell me the version number policy. e.g. shall I just read the version from the toml?

Tag @esemeniuc 