### PR TITLE
[JIT-984] Support e2e shred latency metrics to influx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,7 @@ dependencies = [
  "itertools",
  "jito-protos",
  "log",
+ "prost",
  "prost-types",
  "reqwest",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ hostname = "0.3.1"
 itertools = "0.10"
 jito-protos = { path = "./jito_protos" }
 log = "0.4.14"
-prost-types = "0.11.6"
+prost = "0.11"
+prost-types = "0.11"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde_json = "1"
 signal-hook = "0.3"

--- a/jito_protos/build.rs
+++ b/jito_protos/build.rs
@@ -7,6 +7,7 @@ fn main() {
                 "protos/auth.proto",
                 "protos/shared.proto",
                 "protos/shredstream.proto",
+                "protos/trace_shred.proto",
             ],
             &["protos"],
         )

--- a/jito_protos/src/lib.rs
+++ b/jito_protos/src/lib.rs
@@ -9,3 +9,7 @@ pub mod auth {
 pub mod shredstream {
     tonic::include_proto!("shredstream");
 }
+
+pub mod trace_shred {
+    tonic::include_proto!("trace_shred");
+}

--- a/src/forwarder.rs
+++ b/src/forwarder.rs
@@ -183,8 +183,7 @@ fn recv_from_channel_and_send_multiple_dest(
         packet_batch_vec[0]
             .iter()
             .filter_map(|p| TraceShred::decode(p.data(..)?).ok())
-            .filter(|p| p.region.eq(&metrics.log_context.as_ref().unwrap().region)) // ignore other regions
-            .filter(|p| p.created_at.is_some())
+            .filter(|t| t.created_at.is_some())
             .for_each(|trace_shred| {
                 let elapsed = trace_shred_received_time
                     .duration_since(SystemTime::try_from(trace_shred.created_at.unwrap()).unwrap())

--- a/src/forwarder.rs
+++ b/src/forwarder.rs
@@ -143,7 +143,7 @@ fn recv_from_channel_and_send_multiple_dest(
         Ok(x) => Ok(x),
         Err(e) => Err(ShredstreamProxyError::RecvError(e)),
     }?;
-    let trace_received_time = SystemTime::now();
+    let trace_shred_received_time = SystemTime::now();
     metrics
         .agg_received
         .fetch_add(packet_batch.len() as u64, Ordering::Relaxed);
@@ -186,7 +186,7 @@ fn recv_from_channel_and_send_multiple_dest(
             .filter(|p| p.region.eq(&metrics.log_context.as_ref().unwrap().region)) // ignore other regions
             .filter(|p| p.created_at.is_some())
             .for_each(|trace_shred| {
-                let elapsed = trace_received_time
+                let elapsed = trace_shred_received_time
                     .duration_since(SystemTime::try_from(trace_shred.created_at.unwrap()).unwrap())
                     .unwrap();
                 datapoint_info!("shredstream_proxy-trace_shred_latency",

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,10 @@ struct CommonArgs {
     #[arg(long, env, default_value_t = 15_000)]
     metrics_report_interval_ms: u64,
 
+    /// Logs trace shreds cli and influx
+    #[arg(long, env, default_value_t = false)]
+    debug_trace_shred: bool,
+
     /// Public IP address to use.
     /// Overrides value fetched from `ifconfig.me`.
     #[arg(long, env)]
@@ -263,6 +267,7 @@ fn main() -> Result<(), ShredstreamProxyError> {
         deduper.clone(),
         metrics.clone(),
         use_discovery_service,
+        args.debug_trace_shred,
         shutdown_receiver.clone(),
         exit.clone(),
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use std::{
 use arc_swap::ArcSwap;
 use clap::{arg, Parser};
 use crossbeam_channel::{Receiver, RecvError, Sender};
-use env_logger::TimestampPrecision;
 use log::*;
 use signal_hook::consts::{SIGINT, SIGTERM};
 use solana_client::client_error::{reqwest, ClientError};
@@ -57,6 +56,10 @@ struct ShredstreamArgs {
     /// See https://jito-labs.gitbook.io/mev/searcher-resources/block-engine#connection-details
     #[arg(long, env)]
     block_engine_url: String,
+
+    /// Manual override for auth service address. For internal use.
+    #[arg(long, env)]
+    auth_url: Option<String>,
 
     /// Path to keypair file used to authenticate with the backend.
     #[arg(long, env)]
@@ -176,10 +179,9 @@ fn shutdown_notifier(exit: Arc<AtomicBool>) -> io::Result<(Sender<()>, Receiver<
 }
 
 fn main() -> Result<(), ShredstreamProxyError> {
-    env_logger::builder()
-        .format_timestamp(Some(TimestampPrecision::Micros))
-        .init();
+    env_logger::builder().init();
     let all_args: Args = Args::parse();
+    info!("Starting Shredstream with args: {all_args:?}");
 
     let shredstream_args = all_args.shredstream_args.clone();
     // common args
@@ -326,7 +328,8 @@ fn start_heartbeat(
         }),
     );
     let heartbeat_hdl = heartbeat::heartbeat_loop_thread(
-        args.block_engine_url,
+        args.block_engine_url.clone(),
+        args.auth_url.unwrap_or(args.block_engine_url),
         &auth_keypair,
         args.desired_regions,
         SocketAddr::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,6 @@ fn shutdown_notifier(exit: Arc<AtomicBool>) -> io::Result<(Sender<()>, Receiver<
 fn main() -> Result<(), ShredstreamProxyError> {
     env_logger::builder().init();
     let all_args: Args = Args::parse();
-    info!("Starting Shredstream with args: {all_args:?}");
 
     let shredstream_args = all_args.shredstream_args.clone();
     // common args


### PR DESCRIPTION
Some latency measurements:
```
time                elapsed_micros host_id      trace_region trace_seq_num
----                -------------- -------      ------------ -------------
1678837377406363828 421            fa0cf6496eb9 local        3
1678837378406437124 432            fa0cf6496eb9 local        4
1678837379406412131 345            fa0cf6496eb9 local        5
1678837380406605173 469            fa0cf6496eb9 local        6
1678837381406634860 437            fa0cf6496eb9 local        7
1678837382406701966 437            fa0cf6496eb9 local        8
1678837383406743264 447            fa0cf6496eb9 local        9
1678837384406726432 368            fa0cf6496eb9 local        10
1678837385406956604 532            fa0cf6496eb9 local        11
1678837386406979361 490            fa0cf6496eb9 local        12
1678837387406861324 310            fa0cf6496eb9 local        13
1678837388406952519 340            fa0cf6496eb9 local        14
1678837389407109853 431            fa0cf6496eb9 local        15
```

Note: Adds auth_url parameter since we don't have envoy for routing in docker-compose