### PR TITLE
Prevent leaking tokio tasks upon GRPC client restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "jito-shredstream-proxy"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "arc-swap",
  "clap 4.2.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jito-shredstream-proxy"
-version = "0.1.1"
+version = "0.1.3"
 description = "Fast path to receive shreds from Jito, forwarding to local consumers. See https://jito-labs.gitbook.io/mev/searcher-services/shredstream for details."
 authors = ["Jito Team <team@jito.wtf>"]
 homepage = "https://jito.wtf/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4.0
-FROM --platform=linux/amd64 rust:1.66-slim-bullseye as builder
+FROM --platform=linux/amd64 rust:1.64-slim-bullseye as builder
 
 RUN apt-get -qq update && apt-get install -qq -y ca-certificates libssl-dev protobuf-compiler pkg-config
 RUN rustup component add rustfmt && update-ca-certificates

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,13 +333,14 @@ fn start_heartbeat(
     heartbeat::heartbeat_loop_thread(
         args.block_engine_url.clone(),
         args.auth_url.unwrap_or(args.block_engine_url),
-        &auth_keypair,
+        auth_keypair,
         args.desired_regions,
         SocketAddr::new(
             args.common_args.public_ip.unwrap_or_else(get_public_ip),
             args.common_args.src_bind_port,
         ),
         runtime,
+        "shredstream_proxy".to_string(),
         grpc_restart_signal_r,
         shutdown_receiver.clone(),
         exit.clone(),

--- a/src/token_authenticator.rs
+++ b/src/token_authenticator.rs
@@ -1,11 +1,12 @@
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, RwLock,
+        Arc,
     },
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
+use arc_swap::{ArcSwap, ArcSwapAny};
 use jito_protos::auth::{
     auth_service_client::AuthServiceClient, GenerateAuthChallengeRequest,
     GenerateAuthTokensRequest, RefreshAccessTokenRequest, Role, Token,
@@ -16,23 +17,23 @@ use solana_sdk::signature::{Keypair, Signer};
 use thiserror::Error;
 use tokio::{task::JoinHandle, time::sleep};
 use tonic::{
+    metadata::errors::InvalidMetadataValue,
     service::Interceptor,
-    transport,
     transport::{Channel, Endpoint},
     Request, Status,
 };
 
-const AUTHORIZATION_HEADER: &str = "authorization";
-const BEARER: &str = "Bearer ";
-
 /// Adds the token to each requests' authorization header.
-
 #[derive(Debug, Error)]
 pub enum BlockEngineConnectionError {
-    #[error("transport error {0}")]
-    TransportError(#[from] transport::Error),
-    #[error("client error {0}")]
-    ClientError(#[from] Status),
+    #[error("transport error: {0}")]
+    Transport(#[from] tonic::transport::Error),
+
+    #[error("client error: {0}")]
+    Client(#[from] Status),
+
+    #[error("deserializing error")]
+    Deserialization,
 }
 
 pub type BlockEngineConnectionResult<T> = Result<T, BlockEngineConnectionError>;
@@ -40,44 +41,52 @@ pub type BlockEngineConnectionResult<T> = Result<T, BlockEngineConnectionError>;
 /// Manages refreshing the token in a separate thread.
 #[derive(Clone)]
 pub struct ClientInterceptor {
-    /// The token added to each request header.
-    bearer_token: Arc<RwLock<String>>,
+    /// The access token from jito that added to each request header.
+    bearer_token: Arc<ArcSwap<String>>,
 }
 
 impl ClientInterceptor {
     pub async fn new(
         mut auth_service_client: AuthServiceClient<Channel>,
-        keypair: &Arc<Keypair>,
+        keypair: Arc<Keypair>,
         role: Role,
+        service_name: String,
         exit: Arc<AtomicBool>,
-    ) -> BlockEngineConnectionResult<Self> {
-        let (access_token, refresh_token) =
-            Self::auth(&mut auth_service_client, keypair, role).await?;
+    ) -> BlockEngineConnectionResult<(Self, JoinHandle<()>)> {
+        let (
+            Token {
+                value: access_token,
+                expires_at_utc: access_token_expiration,
+            },
+            refresh_token,
+        ) = Self::auth(&mut auth_service_client, &keypair, role).await?;
+        let bearer_token = Arc::new(ArcSwap::from_pointee(access_token));
 
-        let bearer_token = Arc::new(RwLock::new(access_token.value.clone()));
-
-        let _refresh_token_thread = Self::spawn_token_refresh_thread(
+        let refresh_thread_handle = Self::spawn_token_refresh_thread(
             auth_service_client,
             bearer_token.clone(),
             refresh_token,
-            access_token.expires_at_utc.unwrap(),
-            keypair.clone(),
+            access_token_expiration.ok_or(BlockEngineConnectionError::Deserialization)?,
+            keypair,
             role,
+            service_name,
             exit,
         );
 
-        Ok(Self { bearer_token })
+        Ok((Self { bearer_token }, refresh_thread_handle))
     }
 
+    /// Returns (access token, refresh token)
     async fn auth(
         auth_service_client: &mut AuthServiceClient<Channel>,
         keypair: &Keypair,
         role: Role,
     ) -> BlockEngineConnectionResult<(Token, Token)> {
+        let pubkey_vec = keypair.pubkey().as_ref().to_vec();
         let challenge_resp = auth_service_client
             .generate_auth_challenge(GenerateAuthChallengeRequest {
                 role: role as i32,
-                pubkey: keypair.pubkey().as_ref().to_vec(),
+                pubkey: pubkey_vec.clone(),
             })
             .await?
             .into_inner();
@@ -87,118 +96,134 @@ impl ClientInterceptor {
         let tokens = auth_service_client
             .generate_auth_tokens(GenerateAuthTokensRequest {
                 challenge,
-                client_pubkey: keypair.pubkey().as_ref().to_vec(),
+                client_pubkey: pubkey_vec,
                 signed_challenge,
             })
             .await?
             .into_inner();
 
-        Ok((tokens.access_token.unwrap(), tokens.refresh_token.unwrap()))
+        Ok((
+            tokens
+                .access_token
+                .ok_or(BlockEngineConnectionError::Deserialization)?,
+            tokens
+                .refresh_token
+                .ok_or(BlockEngineConnectionError::Deserialization)?,
+        ))
     }
 
+    /// Periodically updates `bearer_token`
+    #[allow(clippy::too_many_arguments)]
     fn spawn_token_refresh_thread(
         mut auth_service_client: AuthServiceClient<Channel>,
-        bearer_token: Arc<RwLock<String>>,
-        refresh_token: Token,
-        access_token_expiration: Timestamp,
+        bearer_token: Arc<ArcSwap<String>>,
+        initial_refresh_token: Token,
+        initial_access_token_expiration: Timestamp,
         keypair: Arc<Keypair>,
         role: Role,
+        service_name: String,
         exit: Arc<AtomicBool>,
-    ) -> JoinHandle<BlockEngineConnectionResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let mut refresh_token = refresh_token;
-            let mut access_token_expiration = access_token_expiration;
+            // refresh token gets us an access token. access token is short-lived
+            let mut refresh_token = initial_refresh_token;
+            let mut access_token_expiration = initial_access_token_expiration;
 
             while !exit.load(Ordering::Relaxed) {
-                let access_token_ttl = SystemTime::try_from(access_token_expiration.clone())
-                    .unwrap()
-                    .duration_since(SystemTime::now())
-                    .unwrap_or_else(|_| Duration::from_secs(0));
+                let now = SystemTime::now();
+
                 let refresh_token_ttl =
                     SystemTime::try_from(refresh_token.expires_at_utc.as_ref().unwrap().clone())
                         .unwrap()
-                        .duration_since(SystemTime::now())
-                        .unwrap_or_else(|_| Duration::from_secs(0));
-
-                let does_access_token_expire_soon = access_token_ttl < Duration::from_secs(5 * 60);
-                let does_refresh_token_expire_soon =
-                    refresh_token_ttl < Duration::from_secs(5 * 60);
-
-                match (
-                    does_refresh_token_expire_soon,
-                    does_access_token_expire_soon,
-                ) {
-                    // re-run entire auth workflow is refresh token expiring soon
-                    (true, _) => {
-                        let is_error = {
-                            if let Ok((new_access_token, new_refresh_token)) =
-                                Self::auth(&mut auth_service_client, &keypair, role).await
-                            {
-                                *bearer_token.write().unwrap() = new_access_token.value.clone();
-                                access_token_expiration = new_access_token.expires_at_utc.unwrap();
-                                refresh_token = new_refresh_token;
-                                false
-                            } else {
-                                true
-                            }
-                        };
-                        datapoint_info!(
-                            "shredstream_proxy-full_auth",
-                            ("is_error", is_error, bool)
-                        );
-                    }
-                    // re-up the access token if it expires soon
-                    (_, true) => {
-                        let is_error = {
-                            if let Ok(refresh_resp) = auth_service_client
-                                .refresh_access_token(RefreshAccessTokenRequest {
-                                    refresh_token: refresh_token.value.clone(),
-                                })
-                                .await
-                            {
-                                let access_token = refresh_resp.into_inner().access_token.unwrap();
-                                *bearer_token.write().unwrap() = access_token.value.clone();
-                                access_token_expiration = access_token.expires_at_utc.unwrap();
-                                false
-                            } else {
-                                true
-                            }
-                        };
-
-                        datapoint_info!(
-                            "shredstream_proxy-refresh_auth",
-                            ("is_error", is_error, bool)
-                        );
-                    }
-                    _ => {
-                        if !exit.load(Ordering::Relaxed) {
-                            sleep(Duration::from_secs(60)).await
-                        };
-                    }
+                        .duration_since(now)
+                        .unwrap_or_default();
+                // re-run entire auth workflow if refresh token expiring soon
+                if refresh_token_ttl < Duration::from_secs(5 * 60) {
+                    let start = Instant::now();
+                    let is_error = {
+                        if let Ok((new_access_token, new_refresh_token)) =
+                            Self::auth(&mut auth_service_client, &keypair, role).await
+                        {
+                            bearer_token.store(Arc::new(new_access_token.value));
+                            access_token_expiration = new_access_token.expires_at_utc.unwrap();
+                            refresh_token = new_refresh_token;
+                            false
+                        } else {
+                            true
+                        }
+                    };
+                    datapoint_info!(
+                        "token_auth",
+                        ("auth_type", "full_auth", String),
+                        ("service", service_name, String),
+                        ("is_error", is_error, bool),
+                        ("latency_us", start.elapsed().as_micros(), i64),
+                    );
+                    continue;
                 }
+
+                let access_token_ttl = SystemTime::try_from(access_token_expiration.clone())
+                    .unwrap()
+                    .duration_since(now)
+                    .unwrap_or_default();
+                // re-up the access token if it expires soon
+                if access_token_ttl < Duration::from_secs(5 * 60) {
+                    let start = Instant::now();
+                    let is_error = {
+                        if let Ok(refresh_resp) = auth_service_client
+                            .refresh_access_token(RefreshAccessTokenRequest {
+                                refresh_token: refresh_token.value.clone(),
+                            })
+                            .await
+                        {
+                            let access_token = refresh_resp.into_inner().access_token.unwrap();
+                            bearer_token.store(Arc::new(access_token.value.clone()));
+                            access_token_expiration = access_token.expires_at_utc.unwrap();
+                            false
+                        } else {
+                            true
+                        }
+                    };
+
+                    datapoint_info!(
+                        "token_auth",
+                        ("auth_type", "access_token", String),
+                        ("service", service_name, String),
+                        ("is_error", is_error, bool),
+                        ("latency_us", start.elapsed().as_micros(), i64),
+                    );
+                    continue;
+                }
+
+                sleep(Duration::from_secs(5)).await;
             }
-            Ok(())
         })
     }
 }
 
 impl Interceptor for ClientInterceptor {
     fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
-        let l_token = self.bearer_token.read().unwrap();
-        if !l_token.is_empty() {
-            request.metadata_mut().insert(
-                AUTHORIZATION_HEADER,
-                format!("{}{}", BEARER, l_token).parse().unwrap(),
-            );
+        let l_token = ArcSwapAny::load(&self.bearer_token);
+        if l_token.is_empty() {
+            return Err(Status::invalid_argument("missing bearer token"));
         }
+        request.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {l_token}")
+                .parse()
+                .map_err(|e: InvalidMetadataValue| Status::invalid_argument(e.to_string()))?,
+        );
 
         Ok(request)
     }
 }
-pub async fn create_grpc_channel(url: &str) -> BlockEngineConnectionResult<Channel> {
-    let mut endpoint = Endpoint::from_shared(url.to_string()).expect("invalid url");
-    if url.contains("https") {
-        endpoint = endpoint.tls_config(tonic::transport::ClientTlsConfig::new())?;
-    }
+
+pub async fn create_grpc_channel(url: String) -> BlockEngineConnectionResult<Channel> {
+    let endpoint = match url.starts_with("https") {
+        true => Endpoint::from_shared(url)
+            .map_err(BlockEngineConnectionError::Transport)?
+            .tls_config(tonic::transport::ClientTlsConfig::new())?,
+        false => Endpoint::from_shared(url).map_err(BlockEngineConnectionError::Transport)?,
+    };
     Ok(endpoint.connect().await?)
 }


### PR DESCRIPTION
Rationale: If grpc client fails to establish for a while, many GRPC clients will be spawned and never cleaned. 

Notes:
- Expose thread handle to be aborted
- Less unwraps
- Simplify matcher logic
- Better datapoints
- Clean up some clones
- Switch sync lock in async context -> Arcswap