### PR TITLE
Metrics cleanup

### DIFF
--- a/proxy/src/heartbeat.rs
+++ b/proxy/src/heartbeat.rs
@@ -52,34 +52,6 @@ impl Drop for ScopedAtomicBool {
     }
 }
 
-/*
-    This is a wrapper around AtomicBool that allows us to scope the lifetime of the AtomicBool to the heartbeat loop.
-    This is useful because we want to ensure that the AtomicBool is set to true when the heartbeat loop exits.
-*/
-struct ScopedAtomicBool {
-    inner: Arc<AtomicBool>,
-}
-
-impl ScopedAtomicBool {
-    fn get_inner_clone(&self) -> Arc<AtomicBool> {
-        self.inner.clone()
-    }
-}
-
-impl Default for ScopedAtomicBool {
-    fn default() -> Self {
-        Self {
-            inner: Arc::new(AtomicBool::new(false)),
-        }
-    }
-}
-
-impl Drop for ScopedAtomicBool {
-    fn drop(&mut self) {
-        self.inner.store(true, Ordering::Relaxed);
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn heartbeat_loop_thread(
     block_engine_url: String,

--- a/proxy/src/heartbeat.rs
+++ b/proxy/src/heartbeat.rs
@@ -111,7 +111,6 @@ pub fn heartbeat_loop_thread(
                     continue; // avoid sending heartbeat, try acquiring grpc client again
                 }
             };
-
             while !exit.load(Ordering::Relaxed) {
                 crossbeam_channel::select! {
                     // send heartbeat


### PR DESCRIPTION
Changes:
- Inline GRPC connection lost handling into loop
- Avoid metrics outputted per listener thread