### PR TITLE
Decode shreds using DATA_COMPLETE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "jito-protos"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "jito-shredstream-proxy"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ahash 0.8.11",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "jito-protos"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "jito-shredstream-proxy"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ahash 0.8.11",
  "arc-swap",
@@ -2579,7 +2579,7 @@ dependencies = [
  "dashmap",
  "env_logger 0.11.7",
  "hostname",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jito-protos",
  "log",
  "prost 0.12.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
 name = "jito-shredstream-proxy"
 version = "0.2.5"
 dependencies = [
+ "ahash 0.8.11",
  "arc-swap",
  "bincode",
  "borsh 1.5.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 description = "Fast path to receive shreds from Jito, forwarding to local consumers. See https://jito-labs.gitbook.io/mev/searcher-services/shredstream for details."
 authors = ["Jito Team <team@jito.wtf>"]
 homepage = "https://jito.wtf/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 description = "Fast path to receive shreds from Jito, forwarding to local consumers. See https://jito-labs.gitbook.io/mev/searcher-services/shredstream for details."
 authors = ["Jito Team <team@jito.wtf>"]
 homepage = "https://jito.wtf/"
@@ -25,7 +25,7 @@ crossbeam-channel = "0.5.8"
 dashmap = "5"
 env_logger = "0.11"
 hostname = "0.4.0"
-itertools = "0.13.0"
+itertools = "0.14.0"
 jito-protos = { path = "jito_protos" }
 log = "0.4"
 prost = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2021"
 lto = "thin"
 
 [workspace.dependencies]
+ahash = "0.8"
 arc-swap = "1.6"
 clap = { version = "4", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"

--- a/bins/serialized_shreds_data_complete_test.bin
+++ b/bins/serialized_shreds_data_complete_test.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6593063e2637789effd2d14747ef98cf96f2832dd22417967efd659444142575
+size 182906039

--- a/p
+++ b/p
@@ -9,8 +9,13 @@ DOCKER_BUILDKIT=1 docker build -t "$ORG/jito-shredstream-proxy:${TAG}" .
 
 docker push "${ORG}/jito-shredstream-proxy:${TAG}"
 
+# push image
+#VERSION=v0.2.0
+#docker build -t jitolabs/jito-shredstream-proxy:$VERSION .
+#docker push jitolabs/jito-shredstream-proxy:$VERSION
+
 # deploy
 #VERSION=v0.2.0
 #git tag $VERSION -f; git push --tags -f
-#docker tag jitolabs/jito-shredstream-proxy:$VERSION jitolabs/shredstream-proxy:latest
-#docker push jitolabs/shredstream-proxy:latest
+#docker tag jitolabs/jito-shredstream-proxy:$VERSION jitolabs/jito-shredstream-proxy:latest
+#docker push jitolabs/jito-shredstream-proxy:latest

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -7,6 +7,7 @@ homepage = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 arc-swap = { workspace = true }
 bincode = { workspace = true }
 borsh = { workspace = true }

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -170,7 +170,7 @@ pub fn reconstruct_shreds<'a, I: Iterator<Item = &'a [u8]>>(
         }
     }
 
-    // try to bincode deserialize, mark shred as completed
+    // deshred and bincode deserialize
     for (slot, fec_set_index) in slot_fec_indexes_to_iterate.iter() {
         let (_all_shreds, state_tracker) = all_shreds.entry(*slot).or_default();
         let Some((start_data_complete_idx, end_data_complete_idx)) =
@@ -200,7 +200,7 @@ pub fn reconstruct_shreds<'a, I: Iterator<Item = &'a [u8]>>(
             Ok(entries) => entries,
             Err(e) => {
                 warn!(
-                        "failed to deserialize bincode payload of size {} for slot {slot} start_data_complete_idx: {start_data_complete_idx} end_data_complete_idx: {end_data_complete_idx}. Err: {e}",
+                        "Failed to deserialize bincode payload of size {} for slot {slot} start_data_complete_idx: {start_data_complete_idx} end_data_complete_idx: {end_data_complete_idx}. Err: {e}",
                         deshredded_payload.len()
                     );
                 metrics

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -174,7 +174,7 @@ pub fn reconstruct_shreds<'a, I: Iterator<Item = &'a [u8]>>(
     for (slot, fec_set_index) in slot_fec_indexes_to_iterate.iter() {
         let (_all_shreds, state_tracker) = all_shreds.entry(*slot).or_default();
         let Some((start_data_complete_idx, end_data_complete_idx)) =
-            get_indexes(&state_tracker, *fec_set_index as usize)
+            get_indexes(state_tracker, *fec_set_index as usize)
         else {
             continue;
         };
@@ -333,16 +333,13 @@ fn update_state_tracker(shred: &Shred, state_tracker: &mut ShredsStateTracker) -
     {
         return None;
     }
-    match &shred {
-        Shred::ShredData(s) => {
-            state_tracker.data_shreds[index] = Some(shred.clone());
-            if s.data_complete() || s.last_in_slot() {
-                state_tracker.data_status[index] = ShredStatus::DataComplete;
-            } else {
-                state_tracker.data_status[index] = ShredStatus::NotDataComplete;
-            }
+    if let Shred::ShredData(s) = &shred {
+        state_tracker.data_shreds[index] = Some(shred.clone());
+        if s.data_complete() || s.last_in_slot() {
+            state_tracker.data_status[index] = ShredStatus::DataComplete;
+        } else {
+            state_tracker.data_status[index] = ShredStatus::NotDataComplete;
         }
-        _ => {}
     };
     Some(index)
 }
@@ -652,7 +649,7 @@ mod tests {
     /// Helper function to compare all shred output
     #[allow(unused)]
     fn debug_to_disk(
-        deshredded_entries: &Vec<(Slot, Vec<solana_entry::entry::Entry>, Vec<u8>)>,
+        deshredded_entries: &[(Slot, Vec<solana_entry::entry::Entry>, Vec<u8>)],
         filepath: &str,
     ) {
         let entries = deshredded_entries

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -9,7 +9,7 @@ use solana_ledger::{
     shred::{
         merkle::{Shred, ShredCode},
         traits::ShredData,
-        ReedSolomonCache, Shredder, DATA_SHREDS_PER_FEC_BLOCK,
+        ReedSolomonCache, Shredder,
     },
 };
 use solana_sdk::clock::{Slot, MAX_PROCESSING_AGE};
@@ -165,6 +165,7 @@ pub fn reconstruct_shreds<'a, I: Iterator<Item = &'a [u8]>>(
                     ),
                 }
             }
+            println!("recovered:{fec_set_recovered_count}");
             if fec_set_recovered_count > 0 {
                 *is_fec_completed = true;
                 shreds.clear();
@@ -316,7 +317,8 @@ fn get_indexes(tracker: &ShredsStateTracker, index: usize) -> Option<(usize, usi
         if left < 0 {
             return Some((0, end)); // no earlier DataComplete
         }
-        if tracker.already_processed_fec_sets[tracker.data[end].as_ref()?.fec_set_index() as usize]
+        if tracker.already_processed_fec_sets
+            [tracker.data[left as usize].as_ref()?.fec_set_index() as usize]
         {
             return None;
         }
@@ -333,9 +335,7 @@ fn get_indexes(tracker: &ShredsStateTracker, index: usize) -> Option<(usize, usi
 fn update_state_tracker(shred: &Shred, state_tracker: &mut ShredsStateTracker) -> Option<usize> {
     let index = shred.index() as usize;
     let fec_set_index = shred.fec_set_index() as usize;
-    if state_tracker.already_processed_fec_sets[fec_set_index]
-        || state_tracker.data[index].is_some()
-    {
+    if state_tracker.already_processed_fec_sets[fec_set_index] {
         return None;
     }
     state_tracker.shreds_received_per_fec_set[fec_set_index] += 1; // new entry

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -217,7 +217,7 @@ pub fn reconstruct_shreds<'a, I: Iterator<Item = &'a [u8]>>(
             Ok(entries) => entries,
             Err(e) => {
                 warn!(
-                        "Failed to deserialize bincode payload of size {} for slot {slot} start_data_complete_idx: {start_data_complete_idx} end_data_complete_idx: {end_data_complete_idx}. Err: {e}",
+                        "Failed to deserialize bincode payload of size {} for slot {slot}, start_data_complete_idx: {start_data_complete_idx}, end_data_complete_idx: {end_data_complete_idx}, unknown_start: {unknown_start}. Err: {e}",
                         deshredded_payload.len()
                     );
                 metrics

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -335,7 +335,10 @@ fn get_indexes(tracker: &ShredsStateTracker, index: usize) -> Option<(usize, usi
 fn update_state_tracker(shred: &Shred, state_tracker: &mut ShredsStateTracker) -> Option<usize> {
     let index = shred.index() as usize;
     let fec_set_index = shred.fec_set_index() as usize;
-    if state_tracker.already_processed_fec_sets[fec_set_index] {
+    if state_tracker.already_processed_fec_sets[fec_set_index]
+        || state_tracker.data[index].is_some()
+        || !matches!(state_tracker.status[index], ShredStatus::Unknown)
+    {
         return None;
     }
     state_tracker.shreds_received_per_fec_set[fec_set_index] += 1; // new entry

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -361,7 +361,8 @@ fn debug_remaining_shreds(
 /// Rules:
 /// * A segment **ends** at the first `DataComplete` *at or after* `index`.
 /// * It **starts** one position after the previous `DataComplete`, or at the beginning of the vector if there is none.
-/// * If an `Unknown` is seen while searching in either direction, the segment is discarded and `None` is returned.
+/// * If an `Unknown` is seen while searching towards the right, the segment is discarded and `None` is returned.
+/// * We allow `Unknown` towards the left since sometimes entire FEC sets are not sent out
 fn get_indexes(
     tracker: &ShredsStateTracker,
     index: usize,

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -680,7 +680,7 @@ mod tests {
                     .iter()
                     .map(|x| {
                         let mut packet = Packet::default();
-                        packet.buffer_mut()[..x.len()].copy_from_slice(&x);
+                        packet.buffer_mut()[..x.len()].copy_from_slice(x);
                         packet.meta_mut().size = x.len();
                         packet
                     })
@@ -737,7 +737,7 @@ mod tests {
                     .filter(|(index, _)| (index + 1) % 3 != 0)
                     .map(|(_i, x)| {
                         let mut packet = Packet::default();
-                        packet.buffer_mut()[..x.len()].copy_from_slice(&x);
+                        packet.buffer_mut()[..x.len()].copy_from_slice(x);
                         packet.meta_mut().size = x.len();
                         packet
                     })
@@ -857,7 +857,7 @@ mod tests {
                     .iter()
                     .map(|x| {
                         let mut packet = Packet::default();
-                        packet.buffer_mut()[..x.len()].copy_from_slice(&x);
+                        packet.buffer_mut()[..x.len()].copy_from_slice(x);
                         packet.meta_mut().size = x.len();
                         packet
                     })
@@ -914,7 +914,7 @@ mod tests {
                     .filter(|(index, _)| (index + 1) % 3 != 0)
                     .map(|(_i, x)| {
                         let mut packet = Packet::default();
-                        packet.buffer_mut()[..x.len()].copy_from_slice(&x);
+                        packet.buffer_mut()[..x.len()].copy_from_slice(x);
                         packet.meta_mut().size = x.len();
                         packet
                     })

--- a/proxy/src/deshred.rs
+++ b/proxy/src/deshred.rs
@@ -201,7 +201,7 @@ pub fn reconstruct_shreds<'a, I: Iterator<Item = &'a [u8]>>(
                 let fec_set_indexes = to_deshred
                     .iter()
                     .filter_map(|s| s.as_ref().map(|s| s.fec_set_index()))
-                    .collect::<HashSet<u32>>(); //fixme invalid size of data
+                    .collect::<HashSet<u32>>();
                 warn!("slot {slot} failed to deshred slot: {slot}, fec_set_indexes: {fec_set_indexes:?}, start_data_complete_idx: {start_data_complete_idx}, end_data_complete_idx: {end_data_complete_idx}. Err: {e}");
                 metrics
                     .fec_recovery_error_count

--- a/proxy/src/forwarder.rs
+++ b/proxy/src/forwarder.rs
@@ -122,10 +122,7 @@ pub fn start_forwarder_threads(
                     let mut all_shreds: ahash::HashMap<
                         Slot,
                         (
-                            ahash::HashMap<
-                                u32, /* fec_set_index */
-                                (bool /* completed */, HashSet<ComparableShred>),
-                            >,
+                            ahash::HashMap<u32 /* fec_set_index */, HashSet<ComparableShred>>,
                             ShredsStateTracker,
                         ),
                     > = ahash::HashMap::with_capacity(MAX_PROCESSING_AGE);
@@ -184,10 +181,7 @@ fn recv_from_channel_and_send_multiple_dest(
     all_shreds: &mut ahash::HashMap<
         Slot,
         (
-            ahash::HashMap<
-                u32, /* fec_set_index */
-                (bool /* completed */, HashSet<ComparableShred>),
-            >,
+            ahash::HashMap<u32 /* fec_set_index */, HashSet<ComparableShred>>,
             ShredsStateTracker,
         ),
     >,

--- a/proxy/src/forwarder.rs
+++ b/proxy/src/forwarder.rs
@@ -100,6 +100,7 @@ pub fn start_forwarder_threads(
             let metrics = metrics.clone();
             let shutdown_receiver = shutdown_receiver.clone();
             let mut deshredded_entries = Vec::new();
+            let mut highest_slot_seen = 0;
             let rs_cache = ReedSolomonCache::default();
             let entry_sender = entry_sender.clone();
             let exit = exit.clone();
@@ -137,6 +138,7 @@ pub fn start_forwarder_threads(
                                     &deduper,
                                     &mut all_shreds, &mut slot_fec_indexes_to_iterate,
                                     &mut deshredded_entries,
+                                    &mut highest_slot_seen,
                                     &rs_cache,
                                     &send_socket,
                                     &local_dest_sockets,
@@ -187,6 +189,7 @@ fn recv_from_channel_and_send_multiple_dest(
     >,
     slot_fec_indexes_to_iterate: &mut HashSet<(Slot, u32)>,
     deshredded_entries: &mut Vec<(Slot, Vec<solana_entry::entry::Entry>, Vec<u8>)>,
+    highest_slot_seen: &mut Slot,
     rs_cache: &ReedSolomonCache,
     send_socket: &UdpSocket,
     local_dest_sockets: &[SocketAddr],
@@ -275,6 +278,7 @@ fn recv_from_channel_and_send_multiple_dest(
             all_shreds,
             slot_fec_indexes_to_iterate,
             deshredded_entries,
+            highest_slot_seen,
             rs_cache,
             metrics,
         );
@@ -664,6 +668,7 @@ mod tests {
         let entry_sender = Arc::new(BroadcastSender::new(1_000));
         let mut all_shreds = ahash::HashMap::default();
         let mut slot_fec_indexes_to_iterate: HashSet<(Slot, u32)> = HashSet::new();
+        let mut highest_slot_seen = 0;
         // send packets
         recv_from_channel_and_send_multiple_dest(
             packet_receiver.recv(),
@@ -674,6 +679,7 @@ mod tests {
             &mut all_shreds,
             &mut slot_fec_indexes_to_iterate,
             &mut Vec::new(),
+            &mut highest_slot_seen,
             &ReedSolomonCache::default(),
             &udp_sender,
             &Arc::new(dest_socketaddrs),

--- a/proxy/src/forwarder.rs
+++ b/proxy/src/forwarder.rs
@@ -78,10 +78,10 @@ pub fn start_forwarder_threads(
     let (reconstruct_tx, reconstruct_rx) = crossbeam_channel::bounded(1_024);
     let mut thread_hdls = Vec::with_capacity(num_threads + 1);
 
-    // make a new thread that receives shreds from recv_from_channel_and_send_multiple_dest and call deshred::reconstruct_shreds in a loop
     if should_reconstruct_shreds {
         let recon_metrics = metrics.clone();
         let exit = exit.clone();
+        // receives shreds from recv_from_channel_and_send_multiple_dest and calls deshred::reconstruct_shreds
         let hdl = std::thread::Builder::new()
             .name("shred_reconstructor".to_string())
             .spawn(move || {
@@ -98,9 +98,8 @@ pub fn start_forwarder_threads(
                 let mut highest_slot_seen: Slot = 0;
                 let rs_cache = ReedSolomonCache::default();
 
-                // main loop
                 while !exit.load(Ordering::Relaxed) {
-                    match reconstruct_rx.recv_timeout(Duration::from_millis(400)) {
+                    match reconstruct_rx.recv_timeout(Duration::from_millis(100)) {
                         Ok(pkt_batch) => {
                             deshred::reconstruct_shreds(
                                 pkt_batch,

--- a/proxy/src/forwarder.rs
+++ b/proxy/src/forwarder.rs
@@ -466,10 +466,14 @@ pub struct ShredMetrics {
     pub entry_count: AtomicU64,
     /// Number of transactions decoded from shreds
     pub txn_count: AtomicU64,
+    /// Number of times we couldn't find the previous DATA_COMPLETE_SHRED flag
+    pub unknown_start_position_count: AtomicU64,
     /// Number of FEC recovery errors
     pub fec_recovery_error_count: AtomicU64,
     /// Number of bincode Entry deserialization errors
     pub bincode_deserialize_error_count: AtomicU64,
+    /// Number of times we couldn't find the previous DATA_COMPLETE_SHRED flag but tried to deshred+deserialize, and failed
+    pub unknown_start_position_error_count: AtomicU64,
 
     // cumulative metrics (persist after reset)
     pub agg_received_cumulative: AtomicU64,
@@ -496,8 +500,10 @@ impl ShredMetrics {
             recovered_count: Default::default(),
             entry_count: Default::default(),
             txn_count: Default::default(),
+            unknown_start_position_count: Default::default(),
             fec_recovery_error_count: Default::default(),
             bincode_deserialize_error_count: Default::default(),
+            unknown_start_position_error_count: Default::default(),
             agg_received_cumulative: Default::default(),
             agg_success_forward_cumulative: Default::default(),
             agg_fail_forward_cumulative: Default::default(),
@@ -537,6 +543,11 @@ impl ShredMetrics {
                 ),
                 ("txn_count", self.txn_count.swap(0, Ordering::Relaxed), i64),
                 (
+                    "unknown_start_position_count",
+                    self.unknown_start_position_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
                     "fec_recovery_error_count",
                     self.fec_recovery_error_count.swap(0, Ordering::Relaxed),
                     i64
@@ -544,6 +555,12 @@ impl ShredMetrics {
                 (
                     "bincode_deserialize_error_count",
                     self.bincode_deserialize_error_count
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "unknown_start_position_error_count",
+                    self.unknown_start_position_error_count
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/proxy/src/forwarder.rs
+++ b/proxy/src/forwarder.rs
@@ -79,7 +79,7 @@ pub fn start_forwarder_threads(
     let mut thread_hdls = Vec::with_capacity(num_threads + 1);
 
     if should_reconstruct_shreds {
-        let recon_metrics = metrics.clone();
+        let metrics = metrics.clone();
         let exit = exit.clone();
         // receives shreds from recv_from_channel_and_send_multiple_dest and calls deshred::reconstruct_shreds
         let hdl = std::thread::Builder::new()
@@ -108,7 +108,7 @@ pub fn start_forwarder_threads(
                                 &mut deshredded_entries,
                                 &mut highest_slot_seen,
                                 &rs_cache,
-                                &recon_metrics,
+                                &metrics,
                             );
 
                             deshredded_entries.drain(..).for_each(

--- a/proxy/src/forwarder.rs
+++ b/proxy/src/forwarder.rs
@@ -603,10 +603,7 @@ mod tests {
     };
     use tokio::sync::broadcast::Sender as BroadcastSender;
 
-    use crate::{
-        deshred::ComparableShred,
-        forwarder::{recv_from_channel_and_send_multiple_dest, ShredMetrics},
-    };
+    use crate::forwarder::{recv_from_channel_and_send_multiple_dest, ShredMetrics};
 
     fn listen_and_collect(listen_socket: UdpSocket, received_packets: Arc<Mutex<Vec<Vec<u8>>>>) {
         let mut buf = [0u8; PACKET_DATA_SIZE];
@@ -671,13 +668,7 @@ mod tests {
             });
 
         let entry_sender = Arc::new(BroadcastSender::new(1_000));
-        let mut all_shreds: ahash::HashMap<
-            Slot,
-            ahash::HashMap<
-                u32, /* fec_set_index */
-                (bool /* completed */, HashSet<ComparableShred>),
-            >,
-        > = ahash::HashMap::default();
+        let mut all_shreds = ahash::HashMap::default();
         let mut slot_fec_indexes_to_iterate: HashSet<(Slot, u32)> = HashSet::new();
         // send packets
         recv_from_channel_and_send_multiple_dest(


### PR DESCRIPTION
Issue: Old version of Shredstream would try to recover shreds on the assumption that each Vec<Entry> is sourced from a single FEC set. This PR tracks it based on DATA_COMPLETE shred flags

### Enhancements
* Introduced `ShredsStateTracker` to track shred states for correct decoding [[1]](diffhunk://#diff-50755fd675209e96e5305be9b483fd98efe1723d031e572d9f5f1a72351ecb60L34-R39) [[2]](diffhunk://#diff-50755fd675209e96e5305be9b483fd98efe1723d031e572d9f5f1a72351ecb60L117-R129)
* Correctly use single thread for shred reconstruction

### Performance Improvements:
* Replaced `std::collections::HashMap` with `ahash::HashMap` for better performance in `proxy/src/forwarder.rs`

### Test Updates:
* Added new test on deshredding Entries that span multiple FEC sets

