### PR TITLE
fix(server): tolerate broadcast Lagged instead of silently ending stream

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -286,7 +286,7 @@ fn main() -> Result<(), ShredstreamProxyError> {
         forwarder::DEDUPER_NUM_BITS,
     )));
 
-    let entry_sender = Arc::new(BroadcastSender::new(100));
+    let entry_sender = Arc::new(BroadcastSender::new(10_000));
     let forward_stats = Arc::new(StreamerReceiveStats::new("shredstream_proxy-listen_thread"));
     let use_discovery_service =
         args.endpoint_discovery_url.is_some() && args.discovered_endpoints_port.is_some();

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -10,8 +10,8 @@ use jito_protos::shredstream::{
     shredstream_proxy_server::{ShredstreamProxy, ShredstreamProxyServer},
     Entry as PbEntry, SubscribeEntriesRequest,
 };
-use log::{debug, info};
-use tokio::sync::broadcast::{Receiver as BroadcastReceiver, Sender};
+use log::{debug, info, warn};
+use tokio::sync::broadcast::{error::RecvError, Receiver as BroadcastReceiver, Sender};
 use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 
 #[derive(Debug)]
@@ -63,11 +63,23 @@ impl ShredstreamProxy for ShredstreamProxyService {
         let mut entry_receiver: BroadcastReceiver<PbEntry> = self.entry_sender.subscribe();
 
         tokio::spawn(async move {
-            while let Ok(entry) = entry_receiver.recv().await {
-                match tx.send(Ok(entry)).await {
-                    Ok(_) => (),
-                    Err(_e) => {
-                        debug!("client disconnected");
+            loop {
+                match entry_receiver.recv().await {
+                    Ok(entry) => {
+                        if tx.send(Ok(entry)).await.is_err() {
+                            debug!("client disconnected");
+                            break;
+                        }
+                    }
+                    Err(RecvError::Lagged(skipped)) => {
+                        warn!(
+                            "client lagged, skipped {} entries, continuing stream",
+                            skipped
+                        );
+                        continue;
+                    }
+                    Err(RecvError::Closed) => {
+                        debug!("broadcast channel closed");
                         break;
                     }
                 }


### PR DESCRIPTION
The SubscribeEntries forwarder used `while let Ok(entry) = recv().await`, which treated `RecvError::Lagged(n)` the same as `Closed` and exited the loop. That dropped the mpsc sender, tonic flushed clean gRPC OK trailers, and the client saw a graceful stream end every time it briefly fell more than 100 entries behind — masking a transient consumer blip as a server- initiated session end. No error surfaced client- or server-side.

Match on RecvError explicitly: on Lagged, log and continue; on Closed, break. Also bump the broadcast channel capacity from 100 to 10_000 so short consumer pauses don't wrap the ring.

Symptom: consumers reconnected every ~20-30s with clean grpc-status=0 trailers, no keepalive / flow-control / GOAWAY events on the wire.