### PR TITLE
Update crossbeam-channel and adopt jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2787,6 +2787,7 @@ dependencies = [
  "solana-sdk",
  "solana-streamer",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
  "tokio",
  "tonic 0.13.1",
 ]
@@ -9106,6 +9107,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ dashmap = "5"
 env_logger = "0.11"
 hostname = "0.4.0"
 itertools = "0.14.0"
-# Same global allocator agave's binaries use. The proxy previously ran on glibc
-# malloc and died twice from heap-metadata corruption aborts ("corrupted size
-# vs. prev_size", sysmalloc assert) under sustained ~30k pps.
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,12 @@ dashmap = "5"
 env_logger = "0.11"
 hostname = "0.4.0"
 itertools = "0.14.0"
+# Same global allocator agave's binaries use. The proxy previously ran on glibc
+# malloc and died twice from heap-metadata corruption aborts ("corrupted size
+# vs. prev_size", sysmalloc assert) under sustained ~30k pps.
+jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
+    "unprefixed_malloc_on_supported_platforms",
+] }
 jito-protos = { path = "jito_protos" }
 log = "0.4"
 prost = "0.13"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -17,6 +17,7 @@ dashmap = { workspace = true }
 env_logger = { workspace = true }
 hostname = { workspace = true }
 itertools = { workspace = true }
+jemallocator = { workspace = true }
 jito-protos = { workspace = true }
 log = { workspace = true }
 prost = { workspace = true }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,3 +1,10 @@
+// Use jemalloc as the global allocator, mirroring agave's binaries
+// (agave validator/src/main.rs). Under glibc malloc the proxy aborted twice
+// with heap-metadata corruption at sustained ~30k pps; jemalloc both avoids
+// glibc-specific heap-layout fragility and gives clearer diagnostics if
+// corruption recurs.
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+use jemallocator::Jemalloc;
 use std::{
     collections::HashMap,
     io,
@@ -34,6 +41,10 @@ use crate::{
     forwarder::ShredMetrics, multicast_config::create_multicast_socket_on_device,
     token_authenticator::BlockEngineConnectionError,
 };
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 mod deshred;
 pub mod forwarder;
 mod heartbeat;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,10 +1,3 @@
-// Use jemalloc as the global allocator, mirroring agave's binaries
-// (agave validator/src/main.rs). Under glibc malloc the proxy aborted twice
-// with heap-metadata corruption at sustained ~30k pps; jemalloc both avoids
-// glibc-specific heap-layout fragility and gives clearer diagnostics if
-// corruption recurs.
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
-use jemallocator::Jemalloc;
 use std::{
     collections::HashMap,
     io,
@@ -41,9 +34,10 @@ use crate::{
     forwarder::ShredMetrics, multicast_config::create_multicast_socket_on_device,
     token_authenticator::BlockEngineConnectionError,
 };
+// Match Agave's allocator for high-throughput packet processing.
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 mod deshred;
 pub mod forwarder;


### PR DESCRIPTION
## Summary

- update `crossbeam-channel` from 0.5.14 to 0.5.15, resolving [RUSTSEC-2025-0024 / CVE-2025-4574](https://rustsec.org/advisories/RUSTSEC-2025-0024.html)
- use jemalloc as the global allocator on supported targets, matching Agave binaries
- harden the proxy after two production glibc heap-corruption aborts under sustained ~30k packets/s

## Production validation

This build has run for more than eight days under the same sustained production workload without another heap-corruption abort or crash. Because the dependency upgrade and allocator change were deployed together, the soak result does not isolate which change prevented recurrence.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets --tests -- -D warnings`
- `cargo test --workspace --all-features` (14 proxy tests pass; three unrelated deshred/UDP tests fail identically on `origin/master` on macOS)

Fixes #72